### PR TITLE
Add XIAPI_INCLUDE_DIR for hermetic/cross builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@ These bindings have been tested with xiAPI version 4.25 on Windows and Linux. Ne
 some new features may be unsupported. All cameras that are supported by xiAPI are also supported by these bindings.
 
 ### Requirements
-To use these bindings, the XIMEA software package must be installed in the default path 
+To use these bindings without configuration, the XIMEA software package must be installed in the default path
 (For Windows: C:\XIMEA; For Linux: /opt/XIMEA).
+
+#### Non-standard library location
+If your xiAPI installation uses a non-standard install directory, set `XIAPI_INCLUDE_DIR` to the path of the `$XIAPI/include`
+path to specify the header location.
 
 ### Documentation
 Specific documentation for this package is still WIP.

--- a/build.rs
+++ b/build.rs
@@ -5,11 +5,18 @@ use std::path::PathBuf;
 
 fn main() {
     let target_os = env::var("CARGO_CFG_TARGET_OS").expect("Unknown target OS");
-    let (link_lib, include_path) = match target_os.as_str() {
-        "windows" => ("xiapi64","C:/XIMEA/API/xiAPI"),
-        "linux" => ("m3api", "/opt/XIMEA/include"),
-        "macos" => ("m3api","/Library/Frameworks/m3api.framework/Headers"),
+    let (link_lib, mut include_path) = match target_os.as_str() {
+        "windows" => ("xiapi64", "C:/XIMEA/API/xiAPI".to_string()),
+        "linux" => ("m3api", "/opt/XIMEA/include".to_string()),
+        "macos" => (
+            "m3api",
+            "/Library/Frameworks/m3api.framework/Headers".to_string(),
+        ),
         x => panic!("Unknown platform: {x}"),
+    };
+
+    if let Ok(override_include_path) = env::var("XIAPI_INCLUDE_DIR") {
+        include_path = override_include_path;
     };
 
     println!("cargo:rerun-if-changed=wrapper.h");
@@ -22,7 +29,7 @@ fn main() {
     }
 
     if target_os.as_str() == "windows" {
-        println!("cargo:rustc-link-search={}",include_path);
+        println!("cargo:rustc-link-search={}", include_path);
     }
 
     let bindings = bindgen::Builder::default()


### PR DESCRIPTION
For users using non-standard library paths (in particular cross arch builds or hermetic builds) the xiAPI path is not where `build.rs` expects it. This PR uses what seems to be the rust `build.rs` defacto standard of using an environment variable as a way to override the include path.